### PR TITLE
set_button_state doesn’t return anything

### DIFF
--- a/buttons.cpp
+++ b/buttons.cpp
@@ -9,7 +9,7 @@ bool button_pushed[ 6 ] = { 0, 0, 0, 0, 0, 0 };
 bool button_released[ 6 ] = { 0, 0, 0, 0, 0, 0 };
 
 
-bool set_button_state( int button, bool value ) {
+void set_button_state( int button, bool value ) {
   // HEXXX uses pull-up, so button pushes are inverted
   value = !value;
   // perists various forms of button states, like rising and falling

--- a/buttons.h
+++ b/buttons.h
@@ -8,7 +8,7 @@ extern bool button_falling[ 6 ];
 extern bool button_pushed[ 6 ];
 extern bool button_released[ 6 ];
 
-bool set_button_state( int button, bool value );
+void set_button_state( int button, bool value );
 
 void reset_button_states(); // call this function after checking rising/falling checks to get correct data in next iteration
 


### PR DESCRIPTION
Fixes a warning:
c++ -std=c++0x -O3 `sdl2-config --cflags` -O3  -c -o buttons.o buttons.cpp
buttons.cpp:27:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
"set_button_state" doesn't return and was declared with return type bool. 
Changed that to void.
