### PR TITLE
Various infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.a
 hexxx
 test
+*_simulator
+*_hardware

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ simulator: $(SIMULATOR_APPS)
 %_simulator: %.o $(SIMULATOR_OBJECTS)
 	$(CC) $(CXXFLAGS) -o $@ $< $(SIMULATOR_OBJECTS) $(SIMULATOR_LIBS) -lpthread
 
+run-%: %
+	./$<
+
 $(HARDWARE_LIBS): force_look
 	cd ws2811 ; make
 	cd gpio ; make

--- a/hexxx_simulator.cpp
+++ b/hexxx_simulator.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
     while( SDL_PollEvent( &event ) ) {
       switch( event.type ) {
         case SDL_QUIT:
-        	exit(1);
+        	exit(0);
         break;
       }
     }
@@ -143,7 +143,7 @@ int main(int argc, char *argv[]) {
     set_button_state( 5, !keystate[ SDL_SCANCODE_W ] );
     
     if( keystate[ SDL_SCANCODE_ESCAPE ] )
-      exit( 1 );
+      exit( 0 );
 
     usleep(15000); // slow down to about 50FPS on a raspberry pi 2
 


### PR DESCRIPTION
added generic run- target, which showed that you used exit(1), which means error ;-)
